### PR TITLE
Store guild members in a set

### DIFF
--- a/web.py
+++ b/web.py
@@ -26,7 +26,7 @@ for guild_id in guild_ids:
     guild.id = guild_id
     guilds[guild_id] = guild
     guild.channels = {}
-    guild.members = []
+    guild.members = set()
     for row in csv.reader(open(f"{PULLCORD_DIR}/channels/{guild_id}/guild.tsv"), delimiter='\t'):
         time, fetchtype, action, type, id = row[0:5]
         data = row[5:]
@@ -43,9 +43,9 @@ for guild_id in guild_ids:
             guild.channels[id] = channel
         elif type == "member":
             if action == "add":
-                guild.members.append(id)
-            elif action == "delete":
-                guild.members.delete(id)
+                guild.members.add(id)
+            elif action == "del" and id in guild.members:
+                guild.members.remove(id)
     
     guild.channels = dict(sorted(guild.channels.items(), key=lambda c: int(c[1].pos) + (1000 if c[1].chantype == "voice" else 0)))
     


### PR DESCRIPTION
Since "add" also means an update to an existing object (e.g. a name change), there can be a lot of duplicate IDs if you use lists and don't check if the item has been added already. This means the member counts on the stats page can be way higher than they should be.

Reference ([FORMAT.md][]):
> If an object has been `add`ed previously and a new `add` entry with the same ID appears, it's considered an update to the existing object. `Del` for an object that hasn't been `add`ed at any time means the object had existed in the past, but it wasn't present at the time of fetching.

[FORMAT.md]: https://github.com/tsudoko/pullcord/blob/e4f8747a34b05ef42911fabb1661ac95ea219984/FORMAT.md